### PR TITLE
Add a basic build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose
+    - name: Format
+      run: rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu && cargo fmt --check
+    - name: Run tests
+      run: cargo test --verbose

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
I believe this is in the right folder. It assumes we're doing tests, but I like `cargo fmt` and think we should just run it. I could also add this to PRs, but main is _fine_. I don't mind having to add some "format" commits. It's open source!

Edit: I forgot this runs on PRs! Look at that!