### PR TITLE
Suppress async trait warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(incomplete_features)]
 #![feature(async_fn_in_trait)]
 
 pub mod model;


### PR DESCRIPTION
We know it's experimental, and we're okay with that (for now).