### PR TITLE
Commit back to memory DB

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -6,7 +6,7 @@ kill_timeout = 5
 processes = []
 
 [env]
-  DATABASE_URL="sqlite://data/minimail.db"
+  DATABASE_URL="sqlite::memory:"
   SQLX_OFFLINE="true"
 
 [experimental]
@@ -15,7 +15,7 @@ processes = []
 
 [mounts]
 source="minimail_data"
-destination="/data"
+destination="/minimail/app/data"
 
 [[services]]
   http_checks = []


### PR DESCRIPTION
I tried deploying a few times and couldn't get it to work, so for now I'm moving back to in memory DB.