### PR TITLE
Remove unnecessary pieces of fly.toml

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -6,16 +6,11 @@ kill_timeout = 5
 processes = []
 
 [env]
-  DATABASE_URL="sqlite::memory:"
   SQLX_OFFLINE="true"
 
 [experimental]
   allowed_public_ports = []
   auto_rollback = true
-
-[mounts]
-source="minimail_data"
-destination="/minimail/app/data"
 
 [[services]]
   http_checks = []


### PR DESCRIPTION
As part of me attaching the fly database, I also removed the storage, as we weren't going to be using it anyways. And we have an DATABASE_URL set in the secrets of fly, so we don't need it in here.