### PR TITLE
Enable offline SQLX compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Build with rust nightly
 FROM rustlang/rust:nightly as chef
 
+ENV SQLX_OFFLINE=true
+
 WORKDIR /app
 
 # Install cargo-chef so we can use it for caching


### PR DESCRIPTION
This will ensure we don't need to rely on env to be set to compile our app.