### PR TITLE
Move API routes to /api path

### DIFF
--- a/src/startup.rs
+++ b/src/startup.rs
@@ -10,8 +10,8 @@ use std::net::TcpListener;
 pub async fn run(listener: TcpListener, pool: Pool<Postgres>) -> Result<()> {
     let app = Router::new()
         .route("/", get(|| async { "Hello, World!" }))
-        .route("/subscriber", get(routes::subscriber))
-        .route("/subscriber", post(routes::create_subscriber))
+        .route("/api/subscriber", get(routes::subscriber))
+        .route("/api/subscriber", post(routes::create_subscriber))
         .with_state(pool);
 
     axum::Server::from_tcp(listener)?

--- a/tests/api/subscribers.rs
+++ b/tests/api/subscribers.rs
@@ -33,7 +33,7 @@ async fn subscribe_redirects_to_origin(pool: PgPool) {
 
     // Act
     let response = client
-        .post(&format!("{}/subscriber", &app.address))
+        .post(&format!("{}/api/subscriber", &app.address))
         .header("Content-Type", "application/x-www-form-urlencoded")
         .header("origin", &app.address)
         .body(body)
@@ -61,7 +61,7 @@ async fn subscribe_persists_email(pool: PgPool) {
 
     // Act
     client
-        .post(&format!("{}/subscriber", &app.address))
+        .post(&format!("{}/api/subscriber", &app.address))
         .header("Content-Type", "application/x-www-form-urlencoded")
         .header("origin", &app.address)
         .body(body)
@@ -89,7 +89,7 @@ async fn subscribe_lists_subscribers(pool: PgPool) {
 
     // Act
     client
-        .post(&format!("{}/subscriber", &app.address))
+        .post(&format!("{}/api/subscriber", &app.address))
         .header("Content-Type", "application/x-www-form-urlencoded")
         .header("origin", &app.address)
         .body(first_subscriber)
@@ -97,7 +97,7 @@ async fn subscribe_lists_subscribers(pool: PgPool) {
         .await
         .expect("Failed to execute request.");
     client
-        .post(&format!("{}/subscriber", &app.address))
+        .post(&format!("{}/api/subscriber", &app.address))
         .header("Content-Type", "application/x-www-form-urlencoded")
         .header("origin", &app.address)
         .body(second_subscriber)
@@ -105,7 +105,7 @@ async fn subscribe_lists_subscribers(pool: PgPool) {
         .await
         .expect("Failed to execute request.");
     let subscribers = client
-        .get(&format!("{}/subscriber", &app.address))
+        .get(&format!("{}/api/subscriber", &app.address))
         .bearer_auth(token)
         .send()
         .await
@@ -126,7 +126,7 @@ async fn subscribe_without_auth_asks_for_it(pool: PgPool) {
 
     // Act
     let response = client
-        .get(&format!("{}/subscriber", &app.address))
+        .get(&format!("{}/api/subscriber", &app.address))
         .send()
         .await
         .expect("Failed to execute request.");
@@ -145,7 +145,7 @@ async fn subscribe_with_invalid_auth_fails(pool: PgPool) {
 
     // Act
     let response = client
-        .get(&format!("{}/subscriber", &app.address))
+        .get(&format!("{}/api/subscriber", &app.address))
         .bearer_auth("BAD_TOKEN")
         .send()
         .await


### PR DESCRIPTION
I could see us easily having additional routes in the future that aren't API specific, so let's get ahead of the game.