### PR TITLE
Drop APP prefix

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -18,10 +18,10 @@ pub fn get_configuration() -> Result<Settings, ConfigError> {
     let base_path = std::env::current_dir().expect("Failed to determine the current directory");
     let configuration_directory = base_path.join("config");
 
-    let environment: Environment = std::env::var("APP_ENVIRONMENT")
+    let environment: Environment = std::env::var("ENVIRONMENT")
         .unwrap_or_else(|_| "local".into())
         .try_into()
-        .expect("Failed to parse APP_ENVIRONMENT.");
+        .expect("Failed to parse ENVIRONMENT.");
 
     let environment_filename = format!("{}.yaml", environment.as_str());
 
@@ -32,13 +32,7 @@ pub fn get_configuration() -> Result<Settings, ConfigError> {
         .add_source(config::File::from(
             configuration_directory.join(environment_filename),
         ))
-        // Add in settings from environment variables (with a prefix of APP and '__' as separator)
-        // E.g. `APP_APPLICATION__PORT=5001 would set `Settings.application.port`
-        .add_source(
-            config::Environment::with_prefix("APP")
-                .prefix_separator("_")
-                .separator("__"),
-        )
+        .add_source(config::Environment::default().separator("_"))
         .build()?;
 
     settings.try_deserialize::<Settings>()


### PR DESCRIPTION
This isn't super intuitive, and is mostly annoying.