### PR TITLE
Pluralize subscribers route path

### DIFF
--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,3 +1,3 @@
 mod subscribers;
 
-pub use subscribers::{create_subscriber, subscriber};
+pub use subscribers::{get_subscribers, subscribe};

--- a/src/routes/subscribers.rs
+++ b/src/routes/subscribers.rs
@@ -12,7 +12,7 @@ use axum::{
 };
 use log::debug;
 
-pub async fn subscriber(
+pub async fn get_subscribers(
     State(data): State<ApplicationData>,
     TypedHeader(authorization): TypedHeader<Authorization<Bearer>>,
 ) -> Result<String, (StatusCode, String)> {
@@ -34,7 +34,7 @@ pub async fn subscriber(
     Ok(emails.join("\n"))
 }
 
-pub async fn create_subscriber(
+pub async fn subscribe(
     State(data): State<ApplicationData>,
     TypedHeader(origin): TypedHeader<Origin>,
     Form(new_subscriber): Form<NewSubscriber>,

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -19,8 +19,8 @@ pub async fn run(
 ) -> Result<()> {
     let app = Router::new()
         .route("/", get(|| async { "Minimail v0.1.0" }))
-        .route("/api/subscribers", get(routes::subscriber))
-        .route("/api/subscribers", post(routes::create_subscriber))
+        .route("/api/subscribers", get(routes::get_subscribers))
+        .route("/api/subscribe", post(routes::subscribe))
         .with_state(ApplicationData {
             admin,
             pool,

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -19,8 +19,8 @@ pub async fn run(
 ) -> Result<()> {
     let app = Router::new()
         .route("/", get(|| async { "Minimail v0.1.0" }))
-        .route("/api/subscriber", get(routes::subscriber))
-        .route("/api/subscriber", post(routes::create_subscriber))
+        .route("/api/subscribers", get(routes::subscriber))
+        .route("/api/subscribers", post(routes::create_subscriber))
         .with_state(ApplicationData {
             admin,
             pool,

--- a/tests/api/subscribers.rs
+++ b/tests/api/subscribers.rs
@@ -43,7 +43,7 @@ async fn subscribe_redirects_to_origin(pool: PgPool) {
 
     // Act
     let response = client
-        .post(&format!("{}/api/subscriber", &app.address))
+        .post(&format!("{}/api/subscribers", &app.address))
         .header("Content-Type", "application/x-www-form-urlencoded")
         .header("origin", &app.address)
         .body(body)
@@ -83,7 +83,7 @@ async fn subscribe_redirects_to_configured_redirect(pool: PgPool) {
 
     // Act
     let response = client
-        .post(&format!("{}/api/subscriber", &app.address))
+        .post(&format!("{}/api/subscribers", &app.address))
         .header("Content-Type", "application/x-www-form-urlencoded")
         .header("origin", &app.address)
         .body(body)
@@ -118,7 +118,7 @@ async fn subscribe_persists_email(pool: PgPool) {
 
     // Act
     client
-        .post(&format!("{}/api/subscriber", &app.address))
+        .post(&format!("{}/api/subscribers", &app.address))
         .header("Content-Type", "application/x-www-form-urlencoded")
         .header("origin", &app.address)
         .body(body)
@@ -152,7 +152,7 @@ async fn subscribe_lists_subscribers(pool: PgPool) {
 
     // Act
     client
-        .post(&format!("{}/api/subscriber", &app.address))
+        .post(&format!("{}/api/subscribers", &app.address))
         .header("Content-Type", "application/x-www-form-urlencoded")
         .header("origin", &app.address)
         .body(first_subscriber)
@@ -160,7 +160,7 @@ async fn subscribe_lists_subscribers(pool: PgPool) {
         .await
         .expect("Failed to execute request.");
     client
-        .post(&format!("{}/api/subscriber", &app.address))
+        .post(&format!("{}/api/subscribers", &app.address))
         .header("Content-Type", "application/x-www-form-urlencoded")
         .header("origin", &app.address)
         .body(second_subscriber)
@@ -168,7 +168,7 @@ async fn subscribe_lists_subscribers(pool: PgPool) {
         .await
         .expect("Failed to execute request.");
     let subscribers = client
-        .get(&format!("{}/api/subscriber", &app.address))
+        .get(&format!("{}/api/subscribers", &app.address))
         .bearer_auth("admin")
         .send()
         .await
@@ -196,7 +196,7 @@ async fn subscribe_without_auth_asks_for_it(pool: PgPool) {
 
     // Act
     let response = client
-        .get(&format!("{}/api/subscriber", &app.address))
+        .get(&format!("{}/api/subscribers", &app.address))
         .send()
         .await
         .expect("Failed to execute request.");
@@ -222,7 +222,7 @@ async fn subscribe_with_invalid_auth_fails(pool: PgPool) {
 
     // Act
     let response = client
-        .get(&format!("{}/api/subscriber", &app.address))
+        .get(&format!("{}/api/subscribers", &app.address))
         .bearer_auth("BAD_TOKEN")
         .send()
         .await

--- a/tests/api/subscribers.rs
+++ b/tests/api/subscribers.rs
@@ -43,7 +43,7 @@ async fn subscribe_redirects_to_origin(pool: PgPool) {
 
     // Act
     let response = client
-        .post(&format!("{}/api/subscribers", &app.address))
+        .post(&format!("{}/api/subscribe", &app.address))
         .header("Content-Type", "application/x-www-form-urlencoded")
         .header("origin", &app.address)
         .body(body)
@@ -83,7 +83,7 @@ async fn subscribe_redirects_to_configured_redirect(pool: PgPool) {
 
     // Act
     let response = client
-        .post(&format!("{}/api/subscribers", &app.address))
+        .post(&format!("{}/api/subscribe", &app.address))
         .header("Content-Type", "application/x-www-form-urlencoded")
         .header("origin", &app.address)
         .body(body)
@@ -118,7 +118,7 @@ async fn subscribe_persists_email(pool: PgPool) {
 
     // Act
     client
-        .post(&format!("{}/api/subscribers", &app.address))
+        .post(&format!("{}/api/subscribe", &app.address))
         .header("Content-Type", "application/x-www-form-urlencoded")
         .header("origin", &app.address)
         .body(body)
@@ -152,7 +152,7 @@ async fn subscribe_lists_subscribers(pool: PgPool) {
 
     // Act
     client
-        .post(&format!("{}/api/subscribers", &app.address))
+        .post(&format!("{}/api/subscribe", &app.address))
         .header("Content-Type", "application/x-www-form-urlencoded")
         .header("origin", &app.address)
         .body(first_subscriber)
@@ -160,7 +160,7 @@ async fn subscribe_lists_subscribers(pool: PgPool) {
         .await
         .expect("Failed to execute request.");
     client
-        .post(&format!("{}/api/subscribers", &app.address))
+        .post(&format!("{}/api/subscribe", &app.address))
         .header("Content-Type", "application/x-www-form-urlencoded")
         .header("origin", &app.address)
         .body(second_subscriber)


### PR DESCRIPTION
Mostly preference, but I prefer when routes for a resource are pluralized, as it matches when I'm most used to seeing in the wild.